### PR TITLE
Use package config to handle non standard install paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 OPT ?= -g -O3
 CFLAGS ?= -std=c99 -pedantic -Wall -W -fno-strict-aliasing $(OPT)
-CLINK ?= -lpthread -lssl -lcrypto -lm -lev
+CFLAGS+=$(shell pkg-config --cflags libev libssl libcrypto)
+CLINK ?= -lpthread -lm $(shell pkg-config --libs libev libssl libcrypto)
 
 TOBJ = pkproto_test.o pkmanager_test.o sha1_test.o utils_test.o
 OBJ = pkerror.o pkproto.o pkconn.o pkblocker.o pkmanager.o \


### PR DESCRIPTION
Ubuntu/debian installs "ev.h" to /usr/include/ev.h
Fedora 17 installs it to /usr/include/libev/ev.h
