### PR TITLE
Ensure project CFLAGS are merged with environment

### DIFF
--- a/contrib/backends/Makefile
+++ b/contrib/backends/Makefile
@@ -5,14 +5,13 @@ CC=$(CROSS)gcc
 LD=$(CROSS)ld
 AR=$(CROSS)ar
 PKG_CONFIG=$(CROSS)pkg-config
-TARGET_CFLAGS ?= -fpic -I/usr/include/libev
-TARGET_CLINK ?= -lev
 TARGET_OBJ ?= 
 
 OPT ?= -g -O3
-CFLAGS ?= -std=c99 -fno-strict-aliasing -I../../include/ $(TARGET_CFLAGS) $(OPT)
+LIB_CFLAGS:= $(CFLAGS) $(OPT) -std=c99 -fno-strict-aliasing -I../../include/ -fpic
+LIB_CFLAGS+=$(shell $(PKG_CONFIG) --cflags libev)
 CWARN ?= -pedantic -Wall -W
-CLINK ?= -L../../lib -lpthread -lssl -lcrypto -lm $(TARGET_CLINK)
+CLINK ?= -L../../lib -lpthread -lssl -lcrypto -lm -lev
 
 HDRS = ../../include/pagekite.h
 
@@ -31,16 +30,16 @@ windows: pagekitec.exe
 	@touch .win32
 
 httpkite: .unix httpkite.o
-	$(CC) $(CFLAGS) -o httpkite httpkite.o $(CLINK) -lpagekite
+	$(CC) $(LIB_CFLAGS) -o httpkite httpkite.o $(CLINK) -lpagekite
 
 hello: .unix hello.o
-	$(CC) $(CFLAGS) -o hello hello.o $(CLINK) -lpagekite
+	$(CC) $(LIB_CFLAGS) -o hello hello.o $(CLINK) -lpagekite
 
 pagekitec: .unix pagekitec.o
-	$(CC) $(CFLAGS) -o pagekitec pagekitec.o $(CLINK) -lpagekite
+	$(CC) $(LIB_CFLAGS) -o pagekitec pagekitec.o $(CLINK) -lpagekite
 
 pagekitec.exe: .win32 pagekitec.o
-	$(CC) $(CFLAGS) -o pagekitec.exe pagekitec.o $(CLINK) -lpagekite_dll
+	$(CC) $(LIB_CFLAGS) -o pagekitec.exe pagekitec.o $(CLINK) -lpagekite_dll
 
 clean:
 	rm -vf tests pagekite[cr] hello httpkite *.exe *.o .win32 .unix
@@ -49,10 +48,10 @@ allclean: clean
 	find . -name '*.o' |xargs rm -vf
 
 httpkite.o: httpkite.c
-	$(CC) $(CFLAGS) -I../../libpagekite $(CWARN) -c $<
+	$(CC) $(LIB_CFLAGS) -I../../libpagekite $(CWARN) -c $<
 
 .c.o:
-	$(CC) $(CFLAGS) $(CWARN) -c $<
+	$(CC) $(LIB_CFLAGS) $(CWARN) -c $<
 
 httpkite.o: $(HDRS)
 pagekite.o: $(HDRS)

--- a/libpagekite/Makefile
+++ b/libpagekite/Makefile
@@ -5,14 +5,13 @@ CC=$(CROSS)gcc
 LD=$(CROSS)ld
 AR=$(CROSS)ar
 PKG_CONFIG=$(CROSS)pkg-config
-TARGET_CFLAGS ?= -fpic -I/usr/include/libev
-TARGET_CLINK ?= -lev
 TARGET_OBJ ?= 
 
 OPT ?= -g -O3
-CFLAGS ?= -std=c99 -fno-strict-aliasing -I../include/ $(TARGET_CFLAGS) $(OPT)
+LIB_CFLAGS:= $(CFLAGS) $(OPT) -std=c99 -I../include -fpic
+LIB_CFLAGS+=$(shell $(PKG_CONFIG) --cflags libev)
 CWARN ?= -pedantic -Wall -W
-CLINK ?= -L. -lpthread -lssl -lcrypto -lm $(TARGET_CLINK)
+CLINK ?= -L. -lpthread -lssl -lcrypto -lm -lev
 
 TOBJ = sha1_test.o
 
@@ -65,26 +64,26 @@ windows: .win32 libpagekite.dll
 	@touch .unix
 
 tests: .unix tests.o $(OBJ) $(TOBJ)
-	$(CC) $(CFLAGS) -o tests tests.o $(OBJ) $(TOBJ) $(CLINK)
+	$(CC) $(LIB_CFLAGS) -o tests tests.o $(OBJ) $(TOBJ) $(CLINK)
 
 libpagekite.so: .unix $(OBJ)
-	$(CC) $(CFLAGS) -shared -o libpagekite.so $(OBJ) $(CLINK)
+	$(CC) $(LIB_CFLAGS) -shared -o libpagekite.so $(OBJ) $(CLINK)
 
 libpagekite-full: .unix $(OBJ) $(ROBJ)
-	$(CC) $(CFLAGS) -shared -o libpagekite.so $(OBJ) $(ROBJ) $(CLINK)
+	$(CC) $(LIB_CFLAGS) -shared -o libpagekite.so $(OBJ) $(ROBJ) $(CLINK)
 
 pagekiter: pagekiter.o $(OBJ) $(ROBJ)
-	$(CC) $(CFLAGS) -o pagekiter pagekiter.o $(OBJ) $(ROBJ) $(CLINK)
+	$(CC) $(LIB_CFLAGS) -o pagekiter pagekiter.o $(OBJ) $(ROBJ) $(CLINK)
 
 libpagekite.dll: .win32 $(OBJ)
 	$(CC) -shared -o libpagekite.dll $(OBJ) $(CLINK) \
               -Wl,--out-implib,libpagekite_dll.a
 
 evwrap.o: mxe/evwrap.c
-	$(CC) $(CFLAGS) -w -c mxe/evwrap.c
+	$(CC) $(LIB_CFLAGS) -w -c mxe/evwrap.c
 
 pagekite.o: pagekite.c
-	$(CC) $(CFLAGS) $(CWARN) $(DEFINES) -DBUILDING_PAGEKITE_DLL=1 -c $<
+	$(CC) $(LIB_CFLAGS) $(CWARN) $(DEFINES) -DBUILDING_PAGEKITE_DLL=1 -c $<
 
 version: pagekite.h.in
 	sed -e "s/@DATE@/`date '+%y%m%d'`/g" <pagekite.h.in >../include/pagekite.h
@@ -96,7 +95,7 @@ allclean: clean
 	find . -name '*.o' |xargs rm -vf
 
 .c.o:
-	$(CC) $(CFLAGS) $(CWARN) $(DEFINES) -c $<
+	$(CC) $(LIB_CFLAGS) $(CWARN) $(DEFINES) -c $<
 
 pagekite.o: $(HDRS)
 pagekiter.o: $(HDRS) $(RHDRS)


### PR DESCRIPTION
-----
I need this (or something similar) to update the openwrt packaging.  See my other pulls for some other related work.  This is a "minimal" patch against the release branch, but the same approach should be taken, along with more work, for master, with it's additional lua deps

-----

CFLAGS unfortunately contain a mix of compiler and target details provided by
the user or their environment, but also flags provided by the project itself.
Particularly, -I flags to the project itself, C standard, and so on.

This uses a new variable, LIB_CFLAGS for the cflags to use when building the
library, which includes any environment provided CFLAGS.

It also includes the use of pkg-config to find the correct include paths for
libev.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>