### PR TITLE
makefiles: use $(MAKE) to allow jobserver to work properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 default:
-	@make native PK_TESTS=0
+	@$(MAKE) native PK_TESTS=0
 
 optimized:
-	@make all OPT="-O3 -s" PK_TESTS=0
+	@$(MAKE) all OPT="-O3 -s" PK_TESTS=0
 
 debug:
-	@cd libpagekite && make tests PK_MEMORY_CANARIES=1 PK_TRACE=1 PK_TESTS=1
-	@make all PK_MEMORY_CANARIES=1 PK_TRACE=1 PK_TESTS=1
+	@cd libpagekite && $(MAKE) tests PK_MEMORY_CANARIES=1 PK_TRACE=1 PK_TESTS=1
+	@$(MAKE) all PK_MEMORY_CANARIES=1 PK_TRACE=1 PK_TESTS=1
 
 debugwindows:
-	@make windows PK_MEMORY_CANARIES=1 PK_TRACE=1 PK_TESTS=1
+	@$(MAKE) windows PK_MEMORY_CANARIES=1 PK_TRACE=1 PK_TESTS=1
 
 all: native windows
 
 native:
 	@echo '=== Building for '`uname`' ==='
-	cd libpagekite && make
+	$(MAKE) -C libpagekite
 	@mv -v libpagekite/*.so lib/
-	cd contrib/backends/ && make
+	$(MAKE) -C contrib/backends
 	@mv -v contrib/backends/pagekitec bin/
 	@echo
 	@echo Note: To run the apps, you may need to do this first:
@@ -27,18 +27,18 @@ native:
 
 windows:
 	@echo '=== Building for win32 ==='
-	cd libpagekite && ../tools/bash.mxe -c 'make windows'
+	../tools/bash.mxe -c '$(MAKE) -C libpagekite windows'
 	@mv -v libpagekite/*.dll libpagekite/*.a lib/
-	cd contrib/backends/ && ../../tools/bash.mxe -c 'make windows'
+	../../tools/bash.mxe -c '$(MAKE) -C contrib/backends windows'
 	@mv -v contrib/backends/*.exe bin/
 	@echo
 
 version:
-	@cd libpagekite && make version
+	@$(MAKE) -C libpagekite version
 
 buildclean:
-	@cd contrib && make clean
-	@cd libpagekite && make clean
+	@$(MAKE) -C contrib clean
+	@$(MAKE) -C libpagekite clean
 
 clean: buildclean
 	rm -rf bin/* lib/*

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,7 +1,7 @@
 default:
-	@cd backends && make
+	@$(MAKE) -C backends
 
 buildclean:
-	@cd backends && make clean
+	@$(MAKE) -C backends clean
 
 clean: buildclean

--- a/contrib/backends/Makefile
+++ b/contrib/backends/Makefile
@@ -24,11 +24,11 @@ all: pagekitec httpkite
 windows: pagekitec.exe
 
 .unix:
-	@make clean
+	@$(MAKE) clean
 	@touch .unix
 
 .win32:
-	@make clean
+	@$(MAKE) clean
 	@touch .win32
 
 httpkite: .unix httpkite.o

--- a/libpagekite/Makefile
+++ b/libpagekite/Makefile
@@ -59,12 +59,12 @@ windows: .win32 libpagekite.dll
 
 .win32:
 	@echo Switching to win32 build mode
-	@make clean
+	@$(MAKE) clean
 	@touch .win32
 
 .unix:
 	@echo Switching to unix build mode
-	@make clean
+	@$(MAKE) clean
 	@touch .unix
 
 tests: .unix tests.o $(OBJ) $(TOBJ)


### PR DESCRIPTION
cd && make won't always pass make jobserver operation properly into submakes.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>