### PR TITLE
Expand lua compatibility

### DIFF
--- a/contrib/backends/Makefile
+++ b/contrib/backends/Makefile
@@ -5,15 +5,28 @@ CC=$(CROSS)gcc
 LD=$(CROSS)ld
 AR=$(CROSS)ar
 PKG_CONFIG=$(CROSS)pkg-config
-TARGET_CFLAGS ?= -fpic -I/usr/include/libev
-TARGET_CLINK ?= -lev
 TARGET_OBJ ?= 
 
-OPT ?= -g -O3
-CFLAGS ?= -std=c99 -fno-strict-aliasing -I../../include/ $(TARGET_CFLAGS) $(OPT)
-CWARN ?= -pedantic -Wall -W
-CLINK ?= -L../../lib -lpthread -lssl -lcrypto \
-         -llua5.1 -ldl -lm -lc $(TARGET_CLINK)
+LIB_CFLAGS:= $(CFLAGS) -std=c99 -fno-strict-aliasing -I../../include/ -fpic
+LIB_LDFLAGS:= ${LDFLAGS} -L../../lib
+LIB_LIBS:= -lpthread -lssl -lcrypt -ldl -lm -lev
+LIB_CFLAGS+=$(shell $(PKG_CONFIG) --cflags libev)
+# lua distro maintainers are teh suck.
+# http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=498416
+# http://lua-users.org/lists/lua-l/2008-09/msg00184.html
+ifeq ($(shell $(PKG_CONFIG) lua5.1 --exists && echo yes),yes)
+  LUA_PKG=lua5.1
+else
+ ifeq ($(shell $(PKG_CONFIG) lua-5.1 --exists && echo yes),yes)
+   LUA_PKG=lua-5.1
+ else
+  ifeq ($(shell $(PKG_CONFIG) lua --exists && echo yes),yes)
+    LUA_PKG=lua
+  endif
+ endif
+endif
+LIB_CFLAGS+=$(shell $(PKG_CONFIG) --cflags $(LUA_PKG))
+LIB_LIBS+=$(shell $(PKG_CONFIG) --libs $(LUA_PKG))
 
 HDRS = ../../include/pagekite.h
 
@@ -32,16 +45,16 @@ windows: pagekitec.exe
 	@touch .win32
 
 httpkite: .unix httpkite.o
-	$(CC) $(CFLAGS) -o httpkite httpkite.o $(CLINK) -lpagekite
+	$(CC) $(LIB_CFLAGS) -o httpkite httpkite.o $(LIB_LDFLAGS) $(LIB_LIBS) -lpagekite
 
 hello: .unix hello.o
-	$(CC) $(CFLAGS) -o hello hello.o $(CLINK) -lpagekite
+	$(CC) $(LIB_CFLAGS) -o hello hello.o $(LIB_LDFLAGS) $(LIB_LIBS) -lpagekite
 
 pagekitec: .unix pagekitec.o
-	$(CC) $(CFLAGS) -o pagekitec pagekitec.o -lpagekite $(CLINK)
+	$(CC) $(LIB_CFLAGS) -o pagekitec pagekitec.o -lpagekite $(LIB_LDFLAGS) $(LIB_LIBS)
 
 pagekitec.exe: .win32 pagekitec.o
-	$(CC) $(CFLAGS) -o pagekitec.exe pagekitec.o $(CLINK) -lpagekite_dll
+	$(CC) $(LIB_CFLAGS) -o pagekitec.exe pagekitec.o $(LIB_LDFLAGS) $(LIB_LIBS) -lpagekite_dll
 
 clean:
 	rm -vf tests pagekite[cr] hello httpkite *.exe *.o .win32 .unix
@@ -50,10 +63,10 @@ allclean: clean
 	find . -name '*.o' |xargs rm -vf
 
 httpkite.o: httpkite.c
-	$(CC) $(CFLAGS) -I../../libpagekite $(CWARN) -c $<
+	$(CC) $(LIB_CFLAGS) -I../../libpagekite -c $<
 
 .c.o:
-	$(CC) $(CFLAGS) $(CWARN) -c $<
+	$(CC) $(LIB_CFLAGS) -c $<
 
 httpkite.o: $(HDRS)
 pagekite.o: $(HDRS)

--- a/libpagekite/Makefile
+++ b/libpagekite/Makefile
@@ -5,14 +5,31 @@ CC=$(CROSS)gcc
 LD=$(CROSS)ld
 AR=$(CROSS)ar
 PKG_CONFIG=$(CROSS)pkg-config
-TARGET_CFLAGS ?= -fpic -I/usr/include/libev
-TARGET_CLINK ?= -lev -llua5.1
+#TARGET_CFLAGS ?= -fpic -I/usr/include/libev
+#TARGET_CLINK ?= -lev -llua-5.1
 TARGET_OBJ ?= 
 
-OPT ?= -g -O3
-CFLAGS ?= -std=c99 -fno-strict-aliasing -I../include/ $(TARGET_CFLAGS) $(OPT)
-CWARN ?= -pedantic -Wall -W
-CLINK ?= -L. -lpthread -lssl -lcrypto -lm $(TARGET_CLINK)
+LIB_CFLAGS:=${CFLAGS} ${CPPFLAGS} -std=c99 -I../include -fpic
+LIB_LDFLAGS:=${LDFLAGS} -L.
+LIB_LIBS:= -lm -lpthread -lssl -lcrypto -lev
+LIB_CFLAGS+=$(shell $(PKG_CONFIG) --cflags libev)
+# lua distro maintainers are teh suck.
+# http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=498416
+# http://lua-users.org/lists/lua-l/2008-09/msg00184.html
+ifeq ($(shell $(PKG_CONFIG) lua5.1 --exists && echo yes),yes)
+  LUA_PKG=lua5.1
+else
+ ifeq ($(shell $(PKG_CONFIG) lua-5.1 --exists && echo yes),yes)
+   LUA_PKG=lua-5.1
+ else
+  ifeq ($(shell $(PKG_CONFIG) lua --exists && echo yes),yes)
+    LUA_PKG=lua
+  endif
+ endif
+endif
+LIB_CFLAGS+=$(shell $(PKG_CONFIG) --cflags $(LUA_PKG))
+LIB_LIBS+=$(shell $(PKG_CONFIG) --libs $(LUA_PKG))
+
 
 TOBJ = sha1_test.o
 
@@ -68,16 +85,18 @@ windows: .win32 libpagekite.dll
 	@touch .unix
 
 tests: .unix tests.o $(OBJ) $(TOBJ)
-	$(CC) $(CFLAGS) -o tests tests.o $(OBJ) $(TOBJ) $(CLINK)
+	$(CC) $(LIB_CFLAGS) -o tests tests.o $(OBJ) $(TOBJ) $(LIB_LDFLAGS)
 
 libpagekite.a: .unix $(OBJ)
 	$(AR) rcs libpagekite.a $(OBJ)
 
 libpagekite.so: .unix $(OBJ)
-	$(CC) $(CFLAGS) -shared -o libpagekite.so $(OBJ) $(CLINK)
+	#$(CC) $(LIB_CFLAGS) -shared -o libpagekite.so $(OBJ) $(LIB_LDFLAGS)
+	$(CC) -shared $(LIB_LDFLAGS) $(OBJ) -o $@ ${LIB_LIBS}
+
 
 libpagekite-full: .unix $(OBJ) $(ROBJ)
-	$(CC) $(CFLAGS) -shared -o libpagekite.so $(OBJ) $(ROBJ) $(CLINK)
+	$(CC) -shared $(LIB_LDFLAGS) -o libpagekite.so $(OBJ) $(ROBJ) $(LIB_LIBS)
 
 pklualua.h: pklua.lua Makefile ../contrib/plugins
 	echo 'static const char* pklualua = (' >pklualua.h
@@ -89,17 +108,17 @@ pklualua.h: pklua.lua Makefile ../contrib/plugins
 	echo ');' >>pklualua.h
 
 pagekiter: pagekiter.o $(OBJ) $(ROBJ)
-	$(CC) $(CFLAGS) -o pagekiter pagekiter.o $(OBJ) $(ROBJ) $(CLINK)
+	$(CC) $(LIB_CFLAGS) -o pagekiter pagekiter.o $(OBJ) $(ROBJ) $(LIB_LDFLAGS) $(LIB_LIBS)
 
 libpagekite.dll: .win32 $(OBJ)
-	$(CC) -shared -o libpagekite.dll $(OBJ) $(CLINK) \
+	$(CC) -shared -o libpagekite.dll $(OBJ) $(LIB_LDFLAGS) $(LIB_LIBS) \
               -Wl,--out-implib,libpagekite_dll.a
 
 evwrap.o: mxe/evwrap.c
-	$(CC) $(CFLAGS) -w -c mxe/evwrap.c
+	$(CC) $(LIB_CFLAGS) -w -c mxe/evwrap.c
 
 pagekite.o: pagekite.c
-	$(CC) $(CFLAGS) $(CWARN) $(DEFINES) -DBUILDING_PAGEKITE_DLL=1 -c $<
+	$(CC) $(LIB_CFLAGS) $(DEFINES) -DBUILDING_PAGEKITE_DLL=1 -c $<
 
 version: pagekite.h.in
 	sed -e "s/@DATE@/`date '+%y%m%d'`/g" <pagekite.h.in >../include/pagekite.h
@@ -111,7 +130,7 @@ allclean: clean
 	find . -name '*.o' |xargs rm -vf
 
 .c.o:
-	$(CC) $(CFLAGS) $(CWARN) $(DEFINES) -c $<
+	$(CC) $(LIB_CFLAGS) $(CWARN) $(DEFINES) -c $<
 
 pagekite.o: $(HDRS)
 pagekiter.o: $(HDRS) $(RHDRS)

--- a/libpagekite/common.h
+++ b/libpagekite/common.h
@@ -145,7 +145,7 @@ typedef unsigned int              uint32_t;
 #endif
 
 #if defined(HAVE_LUA) && (HAVE_LUA != 0)
-#  include <lua5.1/lua.h>
+#  include <lua.h>
 #else
 #  define lua_State void
 #  undef HAVE_LUA

--- a/libpagekite/pklua.c
+++ b/libpagekite/pklua.c
@@ -45,8 +45,8 @@ How it works:
 #include "pklua.h"
 #include "pklualua.h"
 
-#include <lua5.1/lauxlib.h>
-#include <lua5.1/lualib.h>
+#include <lauxlib.h>
+#include <lualib.h>
 
 
 /*** LUA extensions to interact with libpagekite ****************************/


### PR DESCRIPTION
I realize that these patches all overlap, and probably can't be merged as is.  Also, I don't need exactly this, the general problems can be solved in other ways.  The main point of this is to use the standard "include <lua.h>" and let the makefiles and pkg-config pick lua5.1. for now.  (until we work out how to make it work on both lua5.1 and 5.2.....)


* Use pkg-config instead of hard paths.
* Don't explicitly include path in include directives
* Use various lua5.1 names for various distros

This contains one major rollup that should be a standalone commit,
moving the CFLAGS -I directive to always be set, not ignored if a cross
toolchain had already set up CFLAGS.  <<< see the other PR on the release branch >>>

Windows changes are not tested.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>