### PR TITLE
Avoid unhandled exceptions/errors in Java bindings

### DIFF
--- a/bindings/java/net/pagekite/lib/PageKiteAPI.java
+++ b/bindings/java/net/pagekite/lib/PageKiteAPI.java
@@ -91,7 +91,11 @@ public class PageKiteAPI extends Object
     /* FIXME: int pagekite_add_listener(const char* domain, int port, pagekite_callback_t* callback_func, void* callback_data) */
     /* FIXME: int pagekite_enable_lua_plugins(int enable_defaults, char** settings) */
 
+    public static boolean libLoaded;
     static {
-        System.loadLibrary("pagekite");
+        try {
+            System.loadLibrary("pagekite");
+            libLoaded = true;
+        } catch (Throwable t) { }
     }
 }

--- a/contrib/backends/PageKiteTest.java
+++ b/contrib/backends/PageKiteTest.java
@@ -4,6 +4,11 @@ public class PageKiteTest {
     public static void main(String[] args) {
         String Whitelabel_TLD = "pagekite.me";
 
+        if (!PageKiteAPI.libLoaded) {
+            System.err.println("libpagekite could not be loaded");
+            System.exit(1);
+        }
+
         PageKiteAPI.initWhitelabel(
             "PageKiteTest", 25, 25,
             PageKiteAPI.PK_WITH_DEFAULTS,

--- a/tools/make-bindings.py
+++ b/tools/make-bindings.py
@@ -117,8 +117,12 @@ def java_class(constants, functions):
         '',
         '    ' + '\n    '.join(methods),
         '',
+        '    public static boolean libLoaded;',
         '    static {',
-        '        System.loadLibrary("pagekite");',
+        '        try {',
+        '            System.loadLibrary("pagekite");',
+        '            libLoaded = true;',
+        '        } catch (Throwable t) { }',
         '    }',
         '}'])
 


### PR DESCRIPTION
If libpagekite cannot be loaded, an UnsatisfiedLinkError will be
thrown on the first access to PageKiteAPI. Catch this so that the
application has a chance to handle it.