### PR TITLE
Add missing braces.

### DIFF
--- a/libpagekite/pklogging.c
+++ b/libpagekite/pklogging.c
@@ -80,8 +80,10 @@ int pk_log(int level, const char* fmt, ...)
                               "libpagekite", "%.4000s\n", output);
         } else
 #endif
+        {
           fprintf(log_file, "%.4000s\n", output);
           fflush(log_file);
+        }
       }
     }
   }


### PR DESCRIPTION
Default logging in ANDROID uses __android_log_print instead
of stderr, but stderr was still being fflushed after on every
call to pk_log.