### PR TITLE
Remove hardcoded HAVE_OPENSSL and HAVE_LUA defines.

### DIFF
--- a/contrib/backends/pagekitec.c
+++ b/contrib/backends/pagekitec.c
@@ -23,8 +23,6 @@ Note: For alternate license terms, see the file COPYING.md.
 ******************************************************************************/
 
 /* FIXME! */
-#define HAVE_OPENSSL 1
-#define HAVE_LUA 1
 #define HAVE_IPV6 1
 
 #include <pagekite.h>


### PR DESCRIPTION
These will be defined if present when #including pkcommon.h