### PR TITLE
Fix logging to syslog option broken in pagekitec

### DIFF
--- a/contrib/backends/pagekitec.c
+++ b/contrib/backends/pagekitec.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
   flags |= PK_WITH_IPV6;
 #endif
 
-  while (-1 != (ac = getopt(argc, argv, "46a:B:c:CE:F:P:HIo:l:LNn:qRSvWw:Z"))) {
+  while (-1 != (ac = getopt(argc, argv, "46a:B:c:CE:F:P:HIo:l:LNn:qRsSvWw:Z"))) {
     switch (ac) {
       case '4':
         flags &= ~PK_WITH_IPV4;


### PR DESCRIPTION
Syslog support was added to pagekitec in https://github.com/pagekite/libpagekite/commit/29611b400bd2327f6edc521f7d48880e0e60f033, but apparently incompletely merged (https://github.com/pagekite/libpagekite/commit/778e3699a47b5b1b0eeda554274f0cee1ddd95a8), specifically the 's' option was missing in the getopt parameter.