### PR TITLE
Use monotonic clock for measuring elapsed time, deadlines, etc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,22 @@ AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([clock_gettime dup2 gethostbyname gettimeofday inet_ntoa malloc memmove memset select socket strcasecmp strchr strdup strerror strncasecmp strrchr uname sched_yield pthread_yield pthread_yield_np])
 
+# Check for CLOCK_MONOTONIC
+AC_MSG_CHECKING([for CLOCK_MONOTONIC])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <time.h>
+]], [[
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return 0;
+]])], [
+AC_MSG_RESULT([yes])
+AC_DEFINE([HAVE_CLOCK_MONOTONIC], 1,
+          [Define to 1 if you have the `CLOCK_MONOTONIC' constant.])
+], [
+AC_MSG_RESULT([no])
+])
+
 # OpenSSL requires dlopen on some platforms
 AC_SEARCH_LIBS(dlopen, dl)
 

--- a/libpagekite/pkblocker.c
+++ b/libpagekite/pkblocker.c
@@ -369,7 +369,8 @@ int pkb_check_frontend_dns(struct pk_manager* pkm)
 
 void* pkb_tunnel_ping(void* void_fe) {
   struct pk_tunnel* fe = (struct pk_tunnel*) void_fe;
-  struct timeval tv1, tv2, to;
+  struct timespec tp1, tp2;
+  struct timeval to;
   char buffer[1024], printip[1024];
   int sockfd, bytes, want;
 
@@ -382,7 +383,7 @@ void* pkb_tunnel_ping(void* void_fe) {
     fe->priority = 1 + (rand() % 500);
   }
   else {
-    gettimeofday(&tv1, NULL);
+    pk_gettime(&tp1);
     to.tv_sec = pk_state.socket_timeout_s;
     to.tv_usec = 0;
     if ((0 > (sockfd = PKS_socket(fe->ai.ai_family, fe->ai.ai_socktype,
@@ -419,10 +420,10 @@ void* pkb_tunnel_ping(void* void_fe) {
       sleep(2); /* We don't want to return first! */
       return NULL;
     }
-    gettimeofday(&tv2, NULL);
+    pk_gettime(&tp2);
 
-    fe->priority = ((tv2.tv_sec - tv1.tv_sec) * 1000)
-                 + ((tv2.tv_usec - tv1.tv_usec) / 1000)
+    fe->priority = ((tp2.tv_sec - tp1.tv_sec) * 1000)
+                 + ((tp2.tv_nsec - tp1.tv_nsec) / 1000000)
                  + 1;
 
     if (strcasestr(buffer, PK_FRONTEND_OVERLOADED) != NULL) {

--- a/libpagekite/pkconn.c
+++ b/libpagekite/pkconn.c
@@ -46,7 +46,7 @@ void pkc_reset_conn(struct pk_conn* pkc, unsigned int status)
   }
   pkc->status &= ~CONN_STATUS_BITS;
   pkc->status |= status;
-  pkc->activity = time(0);
+  pkc->activity = pk_time();
   pkc->out_buffer_pos = 0;
   pkc->in_buffer_pos = 0;
   pkc->send_window_kb = CONN_WINDOW_SIZE_KB_INITIAL;
@@ -283,7 +283,7 @@ ssize_t pkc_read(struct pk_conn* pkc)
     }
 
     pkc->in_buffer_pos += bytes;
-    pkc->activity = time(0);
+    pkc->activity = pk_time(0);
 
     /* Update KB counter and window... this is a bit messy. */
     pkc->read_bytes += bytes;

--- a/libpagekite/pkhooks.c
+++ b/libpagekite/pkhooks.c
@@ -141,7 +141,7 @@ struct pke_event* _pke_unlocked_post_event(
   if (ev == NULL) ev = &(pke->events[1]); 
 
   ev->event_code = (ev->event_code & PK_EV_SLOT_MASK) | event_type;
-  ev->posted = time(0);
+  ev->posted = pk_time();
   if (ev->event_str != NULL) free(ev->event_str);
   if (event_str != NULL) {
     ev->event_str = strdup(event_str);

--- a/libpagekite/pkhooks.c
+++ b/libpagekite/pkhooks.c
@@ -238,12 +238,9 @@ struct pke_event* pke_await_event(struct pke_events* pke, int timeout)
   pke = (pke != NULL) ? pke : _pke_default_pke;
   struct pke_event* oldest = NULL;
 
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-
   struct timespec deadline;
-  deadline.tv_sec = tv.tv_sec + timeout;
-  deadline.tv_nsec = tv.tv_usec * 1000;
+  pk_gettime(&deadline);
+  deadline.tv_sec += timeout;
 
   do {
     /* Search for an event... */

--- a/libpagekite/pkhooks.h
+++ b/libpagekite/pkhooks.h
@@ -24,7 +24,7 @@ typedef enum {
   PK_HOOK_START_BLOCKER   =  2, /* 0, pk_blocker, pk_manager     => (ignored) */
 
   PK_HOOK_LOG             =  6, /* bytes, log_line, NULL         => log? */
-  PK_HOOK_TICK            =  7, /* time(0), pk_manager, NULL     => (ignored) */
+  PK_HOOK_TICK            =  7, /* pk_time(), pk_manager, NULL   => (ignored) */
   PK_HOOK_CHECK_WORLD     =  8, /* 0=begin, pk_blocker, pk_manager => check? */
                                 /* 1=end, pk_blocker, pk_manager => (ignored) */
   PK_HOOK_CHECK_TUNNELS   =  9, /* 0=begin, pk_blocker, pk_manager => check? */

--- a/libpagekite/pklogging.c
+++ b/libpagekite/pklogging.c
@@ -201,7 +201,7 @@ void pk_dump_conn(char* prefix, struct pk_conn* conn)
   pk_log(PK_LOG_MANAGER_DEBUG, "%s/sockfd: %d", prefix, conn->sockfd);
   pk_log(PK_LOG_MANAGER_DEBUG, "%s/activity: %x (%ds ago)", prefix,
                                conn->activity,
-                               time(0) - conn->activity);
+                               pk_time(0) - conn->activity);
   pk_log(PK_LOG_MANAGER_DEBUG, "%s/read_bytes: %d", prefix, conn->read_bytes);
   pk_log(PK_LOG_MANAGER_DEBUG, "%s/read_kb: %d", prefix, conn->read_kb);
   pk_log(PK_LOG_MANAGER_DEBUG, "%s/sent_kb: %d", prefix, conn->sent_kb);

--- a/libpagekite/pkmanager.c
+++ b/libpagekite/pkmanager.c
@@ -236,7 +236,7 @@ static void pkm_chunk_cb(struct pk_tunnel* fe, struct pk_chunk *chunk)
       /* Record this ping, even if not initiated by us. This allows us to
        * use pings as a metric of whether a tunnel is in use, to prevent
        * premature disconnections. */
-      fe->last_ping = time(0);
+      fe->last_ping = pk_time();
     }
   }
   else if (NULL != pkb) {
@@ -957,7 +957,7 @@ int pkm_disconnect_unused(struct pk_manager* pkm) {
   int i, j, pass, disconnect, disconnected, live, ping_window;
 
   PK_TRACE_FUNCTION;
-  ping_window = time(0) - 4*pkm->housekeeping_interval_min;
+  ping_window = pk_time() - 4*pkm->housekeeping_interval_min;
 
   /* The lock must already be held, or we may have nasty bugs. */
   assert(0 != pkm_reconfig_start(pkm));
@@ -1047,7 +1047,7 @@ static void pkm_tick_cb(EV_P_ ev_async* w, int revents)
   struct pk_manager* pkm = (struct pk_manager*) w->data;
   time_t next_tick = pkm->next_tick;
   time_t max_tick;
-  time_t now = time(0);
+  time_t now = pk_time();
   time_t increment = (next_tick / 3);
   time_t inactive = now - pkm->next_tick - increment;
 
@@ -1124,7 +1124,7 @@ static void pkm_tick_cb(EV_P_ ev_async* w, int revents)
   pkm_yield_start(pkm);
 
   /* Finally, trigger the tunnel check on the blocking thread. */
-  if (pkm->last_world_update + pkm->check_world_interval < time(0)) {
+  if (pkm->last_world_update + pkm->check_world_interval < pk_time()) {
     pkb_add_job(&(pkm->blocking_jobs), PK_CHECK_WORLD, 0, pkm);
     /* After checking the state of the world, we are a bit more aggressive
      * about following up on things, reset the fallback. */
@@ -1420,7 +1420,7 @@ struct pk_tunnel* pkm_add_frontend_ai(struct pk_manager* pkm,
              (ai->ai_addrlen > 0) &&
              (0 == addrcmp(fe->ai.ai_addr, ai->ai_addr)))
     {
-      fe->last_configured = time(0);
+      fe->last_configured = pk_time();
       return NULL;
     }
   }
@@ -1434,7 +1434,7 @@ struct pk_tunnel* pkm_add_frontend_ai(struct pk_manager* pkm,
   adding->error_count = 0;
   adding->request_count = 0;
   adding->priority = 0;
-  adding->last_configured = time(0);
+  adding->last_configured = pk_time();
 
   return adding;
 }
@@ -1461,7 +1461,7 @@ struct pk_backend_conn* pkm_alloc_be_conn(struct pk_manager* pkm,
    *        gracefully.
    */
 
-  max_age = time(0);
+  max_age = pk_time();
   pkb_oldest = NULL;
   shift = pkm_sid_shift(sid);
   for (i = 0; i < pkm->be_conn_max; i++) {
@@ -1486,7 +1486,7 @@ struct pk_backend_conn* pkm_alloc_be_conn(struct pk_manager* pkm,
   /* If we get this far, we found no empty slots. Let's complain to the
    * log and, if so configured, kick out the oldest idle connection. */
   if (NULL != (pkb = pkb_oldest)) {
-    max_age = time(0) - pkb->conn.activity;
+    max_age = pk_time(0) - pkb->conn.activity;
     evicting = (pk_state.conn_eviction_idle_s &&
                (pk_state.conn_eviction_idle_s < max_age));
 

--- a/libpagekite/pkrelay.c
+++ b/libpagekite/pkrelay.c
@@ -392,7 +392,7 @@ void pkr_relay_incoming(int result, void* void_data) {
   }
 
   if (result == PARSE_WANT_MORE_DATA) {
-    if (time(NULL) - ics->created > 5) {
+    if (pk_time() - ics->created > 5) {
       /* We don't wait forever for more data; that would make resource
        * exhaustion DOS attacks against the server trivially easy. */
       _pkr_close(ics, 0, "Timed out");
@@ -444,7 +444,7 @@ void pkr_conn_accepted_cb(int sockfd, void* void_pkm)
   ics->hostname = NULL;
   ics->parsed_as = PROTO_UNKNOWN;
   ics->parse_state = PARSE_UNDECIDED;
-  ics->created = time(NULL);
+  ics->created = pk_time();
 
   slen = sizeof(ics->local_addr);
   getsockname(sockfd, (struct sockaddr*) &(ics->local_addr), &slen);

--- a/libpagekite/pkutils.h
+++ b/libpagekite/pkutils.h
@@ -42,6 +42,8 @@ int dbg_write(int, char *, int);
 int set_non_blocking(int);
 int set_blocking(int);
 void sleep_ms(int);
+time_t pk_time();
+void pk_gettime(struct timespec *tp);
 int wait_fd(int, int);
 ssize_t timed_read(int, void*, size_t, int);
 struct addrinfo* copy_addrinfo_data(struct addrinfo* dst, struct addrinfo* src);

--- a/libpagekite/pkwatchdog.c
+++ b/libpagekite/pkwatchdog.c
@@ -39,7 +39,7 @@ time_t pk_global_watchdog_ticker = 0;
 void pkw_pet_watchdog()
 {
    if (pk_global_watchdog_ticker >= 0)
-     pk_global_watchdog_ticker = time(0);
+     pk_global_watchdog_ticker = pk_time();
 }
 
 void* pkw_run_watchdog(void *void_pkm)


### PR DESCRIPTION
Use a monotonic clock if available for measuring elapsed time, deadlines, etc. instead of time(0) or gettimeofday, which are affected by discontinuous jumps in the system time (including time jumping backwards). If clock_gettime(CLOCK_MONOTONIC) is not available, fall back to the previous behaviour (although this is not reliable). See #45.