### PR TITLE
Fix clock_gettime() check.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,23 +138,26 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([clock_gettime dup2 gethostbyname gettimeofday inet_ntoa malloc memmove memset select socket strcasecmp strchr strdup strerror strncasecmp strrchr uname sched_yield pthread_yield pthread_yield_np])
+AC_CHECK_FUNCS([dup2 gethostbyname gettimeofday inet_ntoa malloc memmove memset select socket strcasecmp strchr strdup strerror strncasecmp strrchr uname sched_yield pthread_yield pthread_yield_np])
 
-# Check for CLOCK_MONOTONIC
-AC_MSG_CHECKING([for CLOCK_MONOTONIC])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <time.h>
-]], [[
-  struct timespec t;
-  clock_gettime(CLOCK_MONOTONIC, &t);
-  return 0;
-]])], [
-AC_MSG_RESULT([yes])
-AC_DEFINE([HAVE_CLOCK_MONOTONIC], 1,
-          [Define to 1 if you have the `CLOCK_MONOTONIC' constant.])
-], [
-AC_MSG_RESULT([no])
-])
+# Check for clock_gettime + CLOCK_MONOTONIC
+AC_SEARCH_LIBS(clock_gettime, rt,
+  [
+    AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [Define to 1 if you have clock_gettime.])
+    AC_MSG_CHECKING([whether clock_gettime supports CLOCK_MONOTONIC])
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+        [[#include <time.h>]],
+        [[clockid_t clockType = CLOCK_MONOTONIC;]]
+      )],
+      [
+        AC_MSG_RESULT(yes)
+        AC_DEFINE([HAVE_CLOCK_MONOTONIC], [1], [Define to 1 if clock_gettime supports CLOCK_MONOTONIC.])
+      ],
+      AC_MSG_RESULT(no)
+    )
+  ]
+)
 
 # OpenSSL requires dlopen on some platforms
 AC_SEARCH_LIBS(dlopen, dl)


### PR DESCRIPTION
On some systems it is necessary to link with the "rt" library to be
able to use clock_gettime(). Hence, use AC_SEARCH_LIBS instead of
AC_CHECK_FUNCS to check for clock_gettime(). While we are at this,
only check for CLOCK_MONOTONIC if clock_gettime() is available.