### PR TITLE
Makefile.am: use $(top_builddir) for LDADD

### DIFF
--- a/contrib/backends/Makefile.am
+++ b/contrib/backends/Makefile.am
@@ -3,16 +3,16 @@ AM_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/libpagekite
 bin_PROGRAMS = httpkite pagekitec sshkite
 
 httpkite_SOURCES = httpkite.c
-httpkite_LDADD = $(top_srcdir)/libpagekite/libpagekite.la
+httpkite_LDADD = $(top_builddir)/libpagekite/libpagekite.la
 httpkite_CFLAGS = $(LIBEV_CFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/libpagekite
 
 sshkite_SOURCES = sshkite.c
-sshkite_LDADD = $(top_srcdir)/libpagekite/libpagekite.la
+sshkite_LDADD = $(top_builddir)/libpagekite/libpagekite.la
 sshkite_CFLAGS = $(LIBEV_CFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/libpagekite
 
 pagekitec_SOURCES = pagekitec.c
 pagekitec_CFLAGS = $(LIBEV_CFLAGS) $(LUA_INCLUDE) -I$(top_srcdir)/include -I$(top_srcdir)/libpagekite
-pagekitec_LDADD = $(top_srcdir)/libpagekite/libpagekite.la
+pagekitec_LDADD = $(top_builddir)/libpagekite/libpagekite.la
 pagekitec_LDFLAGS = $(LUA_LIBS)
 
 if HAVE_JAVA

--- a/contrib/relays/Makefile.am
+++ b/contrib/relays/Makefile.am
@@ -4,5 +4,5 @@ bin_PROGRAMS = pagekiter
 
 pagekiter_SOURCES = pagekiter.c
 pagekiter_CFLAGS = $(LIBEV_CFLAGS) $(LUA_INCLUDE) -I$(top_srcdir)/include -I$(top_srcdir)/libpagekite
-pagekiter_LDADD = $(top_srcdir)/libpagekite/libpagekite.la
+pagekiter_LDADD = $(top_builddir)/libpagekite/libpagekite.la
 pagekiter_LDFLAGS = $(LUA_LIBS)


### PR DESCRIPTION
When building out-of-tree, top_builddir != top_srcdir. For includes,
top_srcdir should be used because they are not generated. For binaries,
however (i.e. the .la files included in LDADD), top_builddir must be
used. Otherwise linking will fail because the .la file is not found in
the source directory.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>