### PR TITLE
Add threadsafe version of pagekite_get_log (naming TBD?)

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -34,6 +34,7 @@
       * [`pagekite_event_respond_with_data            `](#pgktvntrspndwthdt)
       * [`pagekite_get_status                         `](#pgktgtstts)
       * [`pagekite_get_log                            `](#pgktgtlg)
+      * [`pagekite_get_log_threadsafe                 `](#pgktgtlgts)
       * [`pagekite_dump_state_to_log                  `](#pgktdmpstttlg)
       * [`pagekite_poll                               `](#pgktpll)
       * [`pagekite_tick                               `](#pgkttck)
@@ -720,6 +721,8 @@ Fetch the in-memory log buffer.
 Note that the C-API version returns a pointer to a static buffer.
 Subsequent calls will overwrite with new data.
 
+This function is not threadsafe or reentrant, for that, use `pagekite_get_log_threadsafe`.
+
 This function can be called at any time.
 
 **Arguments**:
@@ -728,6 +731,22 @@ This function can be called at any time.
 
 **Returns**: A snapshot of the current log status.
 
+
+<a                                                     name="pgktgtlgts"><hr></a>
+
+#### `char *pagekite_get_log_threadsafe(...)`
+
+Fetch the in-memory log buffer.
+
+This function can be called at any time.
+
+**Arguments**:
+
+   * `pagekite_mgr`: A reference to the PageKite manager object
+
+This function is like `pagekite_get_log`, but is reentrant and threadsafe.
+
+**Returns**: A snapshot of the current log status; the buffer returned should be subsequently freed.
 
 <a                                                name="pgktdmpstttlg"><hr></a>
 
@@ -893,4 +912,4 @@ PK_EV_RESPOND_OK = 0x00000001
 PK_EV_RESPOND_ACCEPT = 0x00000002  
 PK_EV_RESPOND_FALSE = 0x0000ff00  
 PK_EV_RESPOND_ABORT = 0x00000100  
-PK_EV_RESPOND_REJECT = 0x00000200  
+PK_EV_RESPOND_REJECT = 0x00000200

--- a/libpagekite/pagekite.c
+++ b/libpagekite/pagekite.c
@@ -608,6 +608,19 @@ char* pagekite_get_log(pagekite_mgr pkm) {
   return buffer;
 }
 
+char* pagekite_get_log_threadsafe(pagekite_mgr pkm) {
+  char *buffer;
+  if (pkm == NULL) {
+    buffer = strdup(buffer, "Not running.");
+  }
+  else {
+    char tmp[PKS_LOG_DATA_MAX+1];
+    pks_copylog(tmp);
+    buffer = strdup(tmp);
+  }
+  return buffer;
+}
+
 int pagekite_dump_state_to_log(pagekite_mgr pkm)
 {
   pk_dump_state(PK_MANAGER(pkm));

--- a/libpagekite/pagekite.h.in
+++ b/libpagekite/pagekite.h.in
@@ -715,6 +715,18 @@ DECLSPEC_DLL char* pagekite_get_log(
 );
 
 
+/* Lifecycle: Fetch the in-memory log buffer.
+ *
+ *   This function is like pagekite_get_log, but is reentrant and threadsafe.
+ *
+ * Returns: a snapshot of the current log status; the buffer returned should be
+ * subsequently freed.
+ */
+DECLSPEC_DLL char* char* pagekite_get_log_threadsafe(
+    pagekite_mgr        /* A reference to the PageKite manager object */
+);
+
+
 /* Lifecycle: Dump summary of internal state to log.
  *
  *    This function can be called at any time.


### PR DESCRIPTION
This is more of a WIP commit than anything else and a request for feedback.

Basically, pagekite_get_log is not threadsafe. The use of a static buffer is convenient, but it will corrupt data if you use it from more than one thread. Not nice. So for the use case where someone may want the log from a thread (or more than one), this is introduced