### PR TITLE
sslinit: Fix compilation without deprecated APIs

### DIFF
--- a/libpagekite/pkcommon.h
+++ b/libpagekite/pkcommon.h
@@ -143,6 +143,7 @@ typedef unsigned int              uint32_t;
 #    define SSL_OP_NO_COMPRESSION 0
 #  endif
 #  define PKS_DEFAULT_CIPHERS "HIGH:!aNULL:!eNULL:!LOW:!MD5:!EXP:!PSK:!SRP:!DSS"
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #  define PKS_SSL_INIT(ctx) {\
               SSL_load_error_strings(); \
               ERR_load_BIO_strings(); \
@@ -152,6 +153,13 @@ typedef unsigned int              uint32_t;
               ctx = SSL_CTX_new(SSLv23_method()); \
               SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION); \
               SSL_CTX_set_mode(ctx, SSL_MODE_RELEASE_BUFFERS); }
+#else
+#  define PKS_SSL_INIT(ctx) {\
+              sk_SSL_COMP_zero(SSL_COMP_get_compression_methods()); \
+              ctx = SSL_CTX_new(TLS_method()); \
+              SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION); \
+              SSL_CTX_set_mode(ctx, SSL_MODE_RELEASE_BUFFERS); }
+#endif
 #else
 #  define SSL_CTX                   void
 #  define PKS_DEFAULT_CIPHERS       NULL


### PR DESCRIPTION
All of the removed APIs are either removed or unnecessary.