### PR TITLE
pkmanager: add missing log format

### DIFF
--- a/libpagekite/pkmanager.c
+++ b/libpagekite/pkmanager.c
@@ -1396,7 +1396,7 @@ int pkm_lookup_and_add_frontend(struct pk_manager* pkm,
   }
   else {
     pk_log(PK_LOG_BE_CONNS|PK_LOG_ERROR,
-           "pkm_lookup_and_add_frontend: getaddrinfo(%s, %s) failed:",
+           "pkm_lookup_and_add_frontend: getaddrinfo(%s, %s) failed: %s",
            hostname, sport, gai_strerror(rv));
   }
 


### PR DESCRIPTION
Fixes the missing explanation of the getaddrinfo failure.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>