### PR TITLE
pkproto.c: fix use-after-free that did cause pagekite to SIGSEGV

### DIFF
--- a/libpagekite/pkproto.c
+++ b/libpagekite/pkproto.c
@@ -766,9 +766,9 @@ char *pk_parse_kite_request(
   free(copy);
 
   /* Pass judgement */
-  if ('\0' == *public_domain) return pk_err_null(ERR_PARSE_NO_KITENAME);
-  if ('\0' == *bsalt) return pk_err_null(ERR_PARSE_NO_BSALT);
-  if ('\0' == *fsalt) return pk_err_null(ERR_PARSE_NO_FSALT);
+  if ('\0' == *(kite->public_domain)) return pk_err_null(ERR_PARSE_NO_KITENAME);
+  if ('\0' == *(kite_r->bsalt)) return pk_err_null(ERR_PARSE_NO_BSALT);
+  if ('\0' == *(kite_r->fsalt)) return pk_err_null(ERR_PARSE_NO_FSALT);
   return kite->public_domain;
 }
 


### PR DESCRIPTION
- occasionally, with higher probability on faster/multicore systems
- like: never crashed in years on RPi B+, crashed 95% of all startup attempts on Rpi3 or Rpi4